### PR TITLE
A KZG module whose MSM process have been offloaded to the disk memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +617,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,7 +656,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -763,6 +797,12 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -897,6 +937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +969,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -974,6 +1020,19 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1084,6 +1143,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1239,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1319,6 +1400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocheck"
 version = "0.1.0"
 dependencies = [
@@ -1341,6 +1431,7 @@ dependencies = [
  "rayon",
  "sha2",
  "sha3",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 ark-ed-on-bls12-381 ={ version = "0.5.0", default-features = false}
 sha2 = "0.10"
+tempfile = "3.20.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -1,26 +1,15 @@
-use ark_ec::{pairing::Pairing, CurveGroup, PrimeGroup, VariableBaseMSM};
+use ark_ec::{pairing::Pairing, PrimeGroup};
 use ark_poly::{DenseUVPolynomial};
 use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness}, Error, PCCommitmentState};
-use ark_ff::{BigInteger, PrimeField, Zero};
-use std::fs::File;
+use ark_ff::{PrimeField, Zero};
 use std::io::{BufWriter, Write};
-use std::path::Path;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::io::{BufReader, Read};
 
 use tempfile::NamedTempFile;
 use std::io::Seek;
-// fn skip_leading_zeros<F: PrimeField, P: DenseUVPolynomial<F>>(
-//     p: &P,
-// ) -> usize {
-//     let mut num_leading_zeros = 0;
-//     while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
-//         num_leading_zeros += 1;
-//     }
-//     // let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
-//     num_leading_zeros
-// }
+
 
 fn msm_offloaded<E: Pairing>(
     bases: &[E::G1],
@@ -96,17 +85,17 @@ where
         let mut scalar_writer = BufWriter::new(&mut scalar_file);
 
         for (b, s) in bases.iter().zip(scalars.iter()) {
-            b.serialize_uncompressed(&mut base_writer);
-            s.serialize_uncompressed(&mut scalar_writer);
+            b.serialize_uncompressed(&mut base_writer).unwrap();
+            s.serialize_uncompressed(&mut scalar_writer).unwrap();
         }
 
-        base_writer.flush();
-        scalar_writer.flush();
+        base_writer.flush().unwrap();
+        scalar_writer.flush().unwrap();
     }
 
     // Rewind file pointers
-    base_file.as_file_mut().rewind();
-    scalar_file.as_file_mut().rewind();
+    base_file.as_file_mut().rewind().unwrap();
+    scalar_file.as_file_mut().rewind().unwrap();
 
     let mut commitment = E::G1::zero();
 

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -1,7 +1,7 @@
-use ark_ec::{pairing::Pairing, CurveGroup, PrimeGroup, VariableBaseMSM};
+use ark_ec::{pairing::Pairing, CurveGroup, VariableBaseMSM};
 use ark_poly::{DenseUVPolynomial};
 use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness}, Error, PCCommitmentState};
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{Zero};
 use std::io::{BufWriter, Write};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -101,7 +101,6 @@ where
 
                 let base = E::G1::deserialize_uncompressed(&*base_buf).unwrap().into_affine();
                 let scalar = E::ScalarField::deserialize_uncompressed(&*scalar_buf).unwrap();
-                // chunk_commit += base.mul_bigint(scalar.into_bigint());
                 let res = <E::G1 as VariableBaseMSM>::msm_unchecked(&vec![base], &vec![scalar]);
                 chunk_commit += res;
                 read_count += 1;

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -1,0 +1,87 @@
+use ark_ec::{pairing::Pairing, CurveGroup, VariableBaseMSM, Group};
+use ark_poly::{DenseUVPolynomial};
+use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness}, Error, PCCommitmentState};
+use ark_ff::{BigInteger, Zero};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+// fn skip_leading_zeros<F: PrimeField, P: DenseUVPolynomial<F>>(
+//     p: &P,
+// ) -> usize {
+//     let mut num_leading_zeros = 0;
+//     while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
+//         num_leading_zeros += 1;
+//     }
+//     // let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
+//     num_leading_zeros
+// }
+
+fn msm_offloaded<E: Pairing>(
+    bases: &[E::G1],
+    scalars: &[E::ScalarField],
+) -> E::G1 {
+    // Write scalars to a temporary file
+    let temp_file_path = "/tmp/scalars.tmp";
+    let file = File::create(temp_file_path).expect("Failed to create temporary file");
+    let mut writer = BufWriter::new(file);
+
+    for scalar in scalars {
+        let scalar_bytes = scalar.into_repr().to_bytes_le();
+        writer.write_all(&scalar_bytes).expect("Failed to write scalar to file");
+    }
+
+    writer.flush().expect("Failed to flush writer");
+
+    // Perform MSM using the bases and scalars
+    let bases_affine: Vec<E::G1Affine> = bases.iter().map(|b| b.into_affine()).collect();
+    let result = E::G1::msm_unchecked(&bases_affine, scalars);
+
+    // Clean up the temporary file
+    std::fs::remove_file(temp_file_path).expect("Failed to remove temporary file");
+
+    result
+}
+
+pub fn fast_commit_unchecked<E, P>(
+    powers: &Powers<E>,
+    polynomial: &P,
+) -> Result<(Commitment<E>, Randomness<E::ScalarField, P>), Error>
+where
+    E: Pairing,
+    P: DenseUVPolynomial<E::ScalarField>,
+{
+    println!("Wassup from fast_commit_unchecked!");
+    // Degree check
+    // ark_poly_commit::kzg10::KZG10::<E, P>::check_degree_is_too_large(polynomial.degree(), powers.size())?;
+
+    // Commit to the polynomial using raw field coeffs (no BigInt conversion)
+    let coeffs = polynomial.coeffs();
+    let num_leading_zeros = coeffs.iter().take_while(|c| c.is_zero()).count();
+    let plain_coeffs = &coeffs[num_leading_zeros..];
+
+    let commitment = E::G1::msm_unchecked(
+        &powers.powers_of_g[num_leading_zeros..],
+        plain_coeffs,
+    );
+
+    let randomness = Randomness::<E::ScalarField, P>::empty();
+
+    // If hiding is requested
+    // let random_commitment = if let Some(hiding_degree) = hiding_bound {
+    //     let mut rng = rng.ok_or(Error::MissingRng)?;
+    //     randomness = Randomness::rand(hiding_degree, false, None, &mut rng);
+    //     ark_poly_commit::kzg10::KZG10::<E, P>::check_hiding_bound(
+    //         randomness.blinding_polynomial.degree(),
+    //         powers.powers_of_gamma_g.len(),
+    //     )?;
+
+    //     let blind_coeffs = randomness.blinding_polynomial.coeffs();
+    //     E::G1::msm_unchecked(&powers.powers_of_gamma_g, blind_coeffs).into_affine()
+    // } else {
+    //     E::G1::zero().into_affine()
+    // };
+
+    // let final_commitment = commitment + &random_commitment;
+    let final_commitment = commitment;
+    Ok((Commitment(final_commitment.into()), randomness))
+}

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -49,8 +49,6 @@ where
     E::G1: CanonicalSerialize + CanonicalDeserialize,
     E::ScalarField: CanonicalSerialize + CanonicalDeserialize,
 {
-    println!("Wassup from fast_commit_unchecked (disk offload)!");
-
     let coeffs = polynomial.coeffs();
     let num_leading_zeros = coeffs.iter().take_while(|c| c.is_zero()).count();
     let mut scalars = &coeffs[num_leading_zeros..];

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -1,4 +1,4 @@
-use ark_ec::{pairing::Pairing, PrimeGroup};
+use ark_ec::{pairing::Pairing, CurveGroup, PrimeGroup, VariableBaseMSM};
 use ark_poly::{DenseUVPolynomial};
 use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness}, Error, PCCommitmentState};
 use ark_ff::{PrimeField, Zero};
@@ -99,10 +99,11 @@ where
                     break;
                 }
 
-                let base = E::G1::deserialize_uncompressed(&*base_buf).unwrap();
+                let base = E::G1::deserialize_uncompressed(&*base_buf).unwrap().into_affine();
                 let scalar = E::ScalarField::deserialize_uncompressed(&*scalar_buf).unwrap();
-                chunk_commit += base.mul_bigint(scalar.into_bigint());
-
+                // chunk_commit += base.mul_bigint(scalar.into_bigint());
+                let res = <E::G1 as VariableBaseMSM>::msm_unchecked(&vec![base], &vec![scalar]);
+                chunk_commit += res;
                 read_count += 1;
             }
 

--- a/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/commit_offloaded/mod.rs
@@ -11,22 +11,6 @@ use tempfile::NamedTempFile;
 use std::io::Seek;
 
 
-fn msm_offloaded<E: Pairing>(
-    bases: &[E::G1],
-    scalars: &[E::ScalarField],
-) -> E::G1 {
-    assert_eq!(bases.len(), scalars.len(), "Mismatched input lengths");
-
-    let mut acc = E::G1::zero();
-
-    for (base, scalar) in bases.iter().zip(scalars) {
-        acc += base.mul_bigint(scalar.into_bigint());
-    }
-
-    acc
-}
-
-
 /// Returns slices of aligned bases and scalars with leading zeros trimmed from scalars.
 /// Ensures the lengths match and panics if not enough bases are available.
 pub fn align_msm_inputs<'a, E: Pairing>(

--- a/src/pcs/univariate_pcs/kzg_offloaded/data_structures.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/data_structures.rs
@@ -1,0 +1,10 @@
+use ark_ec::pairing::Pairing;
+use ark_poly::univariate::DensePolynomial;
+use ark_poly_commit::kzg10::Randomness;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct Commitment<E: Pairing> {
+    pub comm: E::G1Affine,
+    pub(crate) rand: Randomness<<E as Pairing>::ScalarField, DensePolynomial<E::ScalarField>>,
+}

--- a/src/pcs/univariate_pcs/kzg_offloaded/mod.rs
+++ b/src/pcs/univariate_pcs/kzg_offloaded/mod.rs
@@ -1,0 +1,201 @@
+use anyhow::Ok;
+use ark_ec::pairing::Pairing;
+use ark_ec::AffineRepr;
+use ark_poly::univariate::DensePolynomial;
+use ark_poly_commit::kzg10::{Commitment as KZGCommitment, Powers, Proof, VerifierKey, KZG10};
+use ark_std::rand::thread_rng;
+use std::marker::PhantomData;
+
+pub mod commit_offloaded;
+use commit_offloaded::fast_commit_unchecked;
+
+pub mod data_structures;
+use data_structures::*;
+use rayon::iter::IndexedParallelIterator;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
+
+use crate::pcs::PolynomialCommitmentScheme;
+
+#[derive(Clone)]
+pub struct KZG<E: Pairing> {
+    _pairing_data: PhantomData<E>,
+}
+
+impl<E: Pairing> PolynomialCommitmentScheme for KZG<E> {
+    type CommitterKey<'a> = Powers<'a, E>;
+    type VerifierKey = VerifierKey<E>;
+    type Commitment = Commitment<E>;
+    type OpeningProof = Proof<E>;
+    type Polynomial = DensePolynomial<E::ScalarField>;
+    type PolynomialInput = E::ScalarField;
+    type PolynomialOutput = E::ScalarField;
+    type PCSParams = usize;
+
+    fn setup(
+        max_degree: &Self::PCSParams,
+    ) -> Result<(Self::CommitterKey<'_>, Self::VerifierKey), anyhow::Error> {
+        // Setting up the KZG(MSM) Polynomial Commitment Scheme
+        let rng = &mut thread_rng();
+        let params = KZG10::<E, DensePolynomial<E::ScalarField>>::setup(*max_degree, false, rng)
+            .expect("PCS setup failed");
+
+        // Computing the verification key
+        let vk = Self::VerifierKey {
+            g: params.powers_of_g[0],
+            gamma_g: params.powers_of_gamma_g[&0],
+            h: params.h,
+            beta_h: params.beta_h,
+            prepared_h: params.prepared_h.clone(),
+            prepared_beta_h: params.prepared_beta_h.clone(),
+        };
+
+        // Computing the powers of the generator 'G'
+        let powers_of_g = params.powers_of_g[..=(*max_degree)].to_vec();
+        let powers_of_gamma_g = (0..=(*max_degree))
+            .map(|i| params.powers_of_gamma_g[&i])
+            .collect();
+
+        let powers = Powers {
+            powers_of_g: ark_std::borrow::Cow::Owned(powers_of_g),
+            powers_of_gamma_g: ark_std::borrow::Cow::Owned(powers_of_gamma_g),
+        };
+
+        Ok((powers, vk))
+    }
+
+
+
+
+     
+    fn commit(
+        ck: &Self::CommitterKey<'_>,
+        poly: &Self::Polynomial,
+    ) -> Result<Self::Commitment, anyhow::Error> {
+        // let (comm, r) =
+        //     KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, poly, None, None).unwrap();
+        
+        let (comm, r) = fast_commit_unchecked(&ck, poly).unwrap();
+
+        assert!(!comm.0.is_zero(), "Commitment should not be zero");
+        assert!(!r.is_hiding(), "Commitment should not be hiding");
+
+        Ok(Self::Commitment {
+            comm: comm.0,
+            rand: r,
+        })
+    }
+
+    fn batch_commit(
+        ck: &Self::CommitterKey<'_>,
+        poly: &Vec<Self::Polynomial>,
+    ) -> Result<Vec<Self::Commitment>, anyhow::Error> {
+        let result: Vec<Self::Commitment> = poly
+            .par_iter()
+            .map(|p| {
+                let (comm, r) =
+                    KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, p, None, None)
+                        .unwrap();
+
+                assert!(!comm.0.is_zero(), "Commitment should not be zero");
+                assert!(!r.is_hiding(), "Commitment should not be hiding");
+
+                Self::Commitment {
+                    comm: comm.0,
+                    rand: r,
+                }
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    fn open(
+        ck: &Self::CommitterKey<'_>,
+        comm: &Self::Commitment,
+        poly: &Self::Polynomial,
+        point: Self::PolynomialInput,
+    ) -> Result<Self::OpeningProof, anyhow::Error> {
+        let opening_proof =
+            KZG10::<E, DensePolynomial<E::ScalarField>>::open(&ck, poly, point, &comm.rand)
+                .unwrap();
+
+        Ok(opening_proof)
+    }
+
+    fn batch_open<'a>(
+        ck: &'a Self::CommitterKey<'_>,
+        comm: &'a Vec<Self::Commitment>,
+        poly: &'a Vec<Self::Polynomial>,
+        point: Self::PolynomialInput,
+    ) -> Result<Vec<Self::OpeningProof>, anyhow::Error> {
+        let result = poly
+            .par_iter()
+            .zip(comm)
+            .map(|(p, c)| {
+                let opening_proof =
+                    KZG10::<E, DensePolynomial<E::ScalarField>>::open(&ck, p, point, &c.rand)
+                        .unwrap();
+
+                opening_proof
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    fn check(
+        vk: &Self::VerifierKey,
+        opening_proof: &Self::OpeningProof,
+        comm: &Self::Commitment,
+        point: Self::PolynomialInput,
+        value: Self::PolynomialOutput,
+    ) -> Result<bool, anyhow::Error> {
+        let kzg_commitment = KZGCommitment { 0: comm.comm };
+
+        let result = KZG10::<E, DensePolynomial<E::ScalarField>>::check(
+            &vk,
+            &kzg_commitment,
+            point,
+            value,
+            opening_proof,
+        )
+        .unwrap();
+
+        Ok(result)
+    }
+
+    fn batch_check<'a>(
+        vk: &'a Self::VerifierKey,
+        opening_proof: &'a Vec<Self::OpeningProof>,
+        comm: &'a Vec<Self::Commitment>,
+        point: Self::PolynomialInput,
+        value: Vec<Self::PolynomialOutput>,
+    ) -> Result<bool, anyhow::Error> {
+        let result: Vec<bool> = comm
+            .par_iter()
+            .zip(opening_proof)
+            .zip(value)
+            .map(|((cm, proof), val)| {
+                let kzg_commitment = KZGCommitment { 0: cm.comm };
+
+                let valid = KZG10::<E, DensePolynomial<E::ScalarField>>::check(
+                    &vk,
+                    &kzg_commitment,
+                    point,
+                    val,
+                    proof,
+                )
+                .unwrap();
+
+                valid
+            })
+            .collect();
+
+        Ok(result.into_iter().fold(true, |res, valid| res & valid))
+    }
+
+    fn extract_pure_commitment(comm: &Self::Commitment) -> Result<Self::Commitment, anyhow::Error> {
+        Ok(comm.clone())
+    }
+}

--- a/src/pcs/univariate_pcs/mod.rs
+++ b/src/pcs/univariate_pcs/mod.rs
@@ -1,3 +1,4 @@
 pub mod hyrax;
 pub mod kzg;
 pub mod ligero;
+pub mod kzg_offloaded;


### PR DESCRIPTION
This pull request contains only the module code. No further changes have been made. If you would like to run this module, please go to `Ken/msm_offload/testing` branch.

The offload is carried out with:
1. Serializing the bases and scalars into vector of bytes, then stored to the disk
2. In a chunk of size `1024`, read the bytes from the disk, deserialize, and accumulate the sum.

A new crate called `tempfile` is also introduced, to create temp files that holds the bases and scalars.