### PR TITLE
Ken/msm_unchecked - A KZG module that uses `msm_unchecked` instead of `msm_bigint`

### DIFF
--- a/src/pcs/univariate_pcs/mod.rs
+++ b/src/pcs/univariate_pcs/mod.rs
@@ -1,3 +1,4 @@
 pub mod hyrax;
 pub mod kzg;
 pub mod ligero;
+pub mod msm_uncheck_kzg;

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/data_structures.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/data_structures.rs
@@ -1,0 +1,10 @@
+use ark_ec::pairing::Pairing;
+use ark_poly::univariate::DensePolynomial;
+use ark_poly_commit::kzg10::Randomness;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct Commitment<E: Pairing> {
+    pub comm: E::G1Affine,
+    pub(crate) rand: Randomness<<E as Pairing>::ScalarField, DensePolynomial<E::ScalarField>>,
+}

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
@@ -75,7 +75,7 @@ impl<E: Pairing> PolynomialCommitmentScheme for KZG<E> {
         // let (comm, r) =
         //     KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, poly, None, None).unwrap();
         
-        let (comm, r) = fast_commit_unchecked(&ck, poly, None, None).unwrap();
+        let (comm, r) = fast_commit_unchecked(&ck, poly).unwrap();
 
         assert!(!comm.0.is_zero(), "Commitment should not be zero");
         assert!(!r.is_hiding(), "Commitment should not be hiding");

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
@@ -6,6 +6,9 @@ use ark_poly_commit::kzg10::{Commitment as KZGCommitment, Powers, Proof, Verifie
 use ark_std::rand::thread_rng;
 use std::marker::PhantomData;
 
+pub mod my_kzg10;
+use my_kzg10::fast_commit_unchecked;
+
 pub mod data_structures;
 use data_structures::*;
 use rayon::iter::IndexedParallelIterator;
@@ -61,12 +64,18 @@ impl<E: Pairing> PolynomialCommitmentScheme for KZG<E> {
         Ok((powers, vk))
     }
 
+
+
+
+     
     fn commit(
         ck: &Self::CommitterKey<'_>,
         poly: &Self::Polynomial,
     ) -> Result<Self::Commitment, anyhow::Error> {
-        let (comm, r) =
-            KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, poly, None, None).unwrap();
+        // let (comm, r) =
+        //     KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, poly, None, None).unwrap();
+        
+        let (comm, r) = fast_commit_unchecked(&ck, poly, None, None).unwrap();
 
         assert!(!comm.0.is_zero(), "Commitment should not be zero");
         assert!(!r.is_hiding(), "Commitment should not be hiding");

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/mod.rs
@@ -1,0 +1,192 @@
+use anyhow::Ok;
+use ark_ec::pairing::Pairing;
+use ark_ec::AffineRepr;
+use ark_poly::univariate::DensePolynomial;
+use ark_poly_commit::kzg10::{Commitment as KZGCommitment, Powers, Proof, VerifierKey, KZG10};
+use ark_std::rand::thread_rng;
+use std::marker::PhantomData;
+
+pub mod data_structures;
+use data_structures::*;
+use rayon::iter::IndexedParallelIterator;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
+
+use crate::pcs::PolynomialCommitmentScheme;
+
+#[derive(Clone)]
+pub struct KZG<E: Pairing> {
+    _pairing_data: PhantomData<E>,
+}
+
+impl<E: Pairing> PolynomialCommitmentScheme for KZG<E> {
+    type CommitterKey<'a> = Powers<'a, E>;
+    type VerifierKey = VerifierKey<E>;
+    type Commitment = Commitment<E>;
+    type OpeningProof = Proof<E>;
+    type Polynomial = DensePolynomial<E::ScalarField>;
+    type PolynomialInput = E::ScalarField;
+    type PolynomialOutput = E::ScalarField;
+    type PCSParams = usize;
+
+    fn setup(
+        max_degree: &Self::PCSParams,
+    ) -> Result<(Self::CommitterKey<'_>, Self::VerifierKey), anyhow::Error> {
+        // Setting up the KZG(MSM) Polynomial Commitment Scheme
+        let rng = &mut thread_rng();
+        let params = KZG10::<E, DensePolynomial<E::ScalarField>>::setup(*max_degree, false, rng)
+            .expect("PCS setup failed");
+
+        // Computing the verification key
+        let vk = Self::VerifierKey {
+            g: params.powers_of_g[0],
+            gamma_g: params.powers_of_gamma_g[&0],
+            h: params.h,
+            beta_h: params.beta_h,
+            prepared_h: params.prepared_h.clone(),
+            prepared_beta_h: params.prepared_beta_h.clone(),
+        };
+
+        // Computing the powers of the generator 'G'
+        let powers_of_g = params.powers_of_g[..=(*max_degree)].to_vec();
+        let powers_of_gamma_g = (0..=(*max_degree))
+            .map(|i| params.powers_of_gamma_g[&i])
+            .collect();
+
+        let powers = Powers {
+            powers_of_g: ark_std::borrow::Cow::Owned(powers_of_g),
+            powers_of_gamma_g: ark_std::borrow::Cow::Owned(powers_of_gamma_g),
+        };
+
+        Ok((powers, vk))
+    }
+
+    fn commit(
+        ck: &Self::CommitterKey<'_>,
+        poly: &Self::Polynomial,
+    ) -> Result<Self::Commitment, anyhow::Error> {
+        let (comm, r) =
+            KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, poly, None, None).unwrap();
+
+        assert!(!comm.0.is_zero(), "Commitment should not be zero");
+        assert!(!r.is_hiding(), "Commitment should not be hiding");
+
+        Ok(Self::Commitment {
+            comm: comm.0,
+            rand: r,
+        })
+    }
+
+    fn batch_commit(
+        ck: &Self::CommitterKey<'_>,
+        poly: &Vec<Self::Polynomial>,
+    ) -> Result<Vec<Self::Commitment>, anyhow::Error> {
+        let result: Vec<Self::Commitment> = poly
+            .par_iter()
+            .map(|p| {
+                let (comm, r) =
+                    KZG10::<E, DensePolynomial<E::ScalarField>>::commit(&ck, p, None, None)
+                        .unwrap();
+
+                assert!(!comm.0.is_zero(), "Commitment should not be zero");
+                assert!(!r.is_hiding(), "Commitment should not be hiding");
+
+                Self::Commitment {
+                    comm: comm.0,
+                    rand: r,
+                }
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    fn open(
+        ck: &Self::CommitterKey<'_>,
+        comm: &Self::Commitment,
+        poly: &Self::Polynomial,
+        point: Self::PolynomialInput,
+    ) -> Result<Self::OpeningProof, anyhow::Error> {
+        let opening_proof =
+            KZG10::<E, DensePolynomial<E::ScalarField>>::open(&ck, poly, point, &comm.rand)
+                .unwrap();
+
+        Ok(opening_proof)
+    }
+
+    fn batch_open<'a>(
+        ck: &'a Self::CommitterKey<'_>,
+        comm: &'a Vec<Self::Commitment>,
+        poly: &'a Vec<Self::Polynomial>,
+        point: Self::PolynomialInput,
+    ) -> Result<Vec<Self::OpeningProof>, anyhow::Error> {
+        let result = poly
+            .par_iter()
+            .zip(comm)
+            .map(|(p, c)| {
+                let opening_proof =
+                    KZG10::<E, DensePolynomial<E::ScalarField>>::open(&ck, p, point, &c.rand)
+                        .unwrap();
+
+                opening_proof
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    fn check(
+        vk: &Self::VerifierKey,
+        opening_proof: &Self::OpeningProof,
+        comm: &Self::Commitment,
+        point: Self::PolynomialInput,
+        value: Self::PolynomialOutput,
+    ) -> Result<bool, anyhow::Error> {
+        let kzg_commitment = KZGCommitment { 0: comm.comm };
+
+        let result = KZG10::<E, DensePolynomial<E::ScalarField>>::check(
+            &vk,
+            &kzg_commitment,
+            point,
+            value,
+            opening_proof,
+        )
+        .unwrap();
+
+        Ok(result)
+    }
+
+    fn batch_check<'a>(
+        vk: &'a Self::VerifierKey,
+        opening_proof: &'a Vec<Self::OpeningProof>,
+        comm: &'a Vec<Self::Commitment>,
+        point: Self::PolynomialInput,
+        value: Vec<Self::PolynomialOutput>,
+    ) -> Result<bool, anyhow::Error> {
+        let result: Vec<bool> = comm
+            .par_iter()
+            .zip(opening_proof)
+            .zip(value)
+            .map(|((cm, proof), val)| {
+                let kzg_commitment = KZGCommitment { 0: cm.comm };
+
+                let valid = KZG10::<E, DensePolynomial<E::ScalarField>>::check(
+                    &vk,
+                    &kzg_commitment,
+                    point,
+                    val,
+                    proof,
+                )
+                .unwrap();
+
+                valid
+            })
+            .collect();
+
+        Ok(result.into_iter().fold(true, |res, valid| res & valid))
+    }
+
+    fn extract_pure_commitment(comm: &Self::Commitment) -> Result<Self::Commitment, anyhow::Error> {
+        Ok(comm.clone())
+    }
+}

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/my_kzg10/mod.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/my_kzg10/mod.rs
@@ -1,35 +1,16 @@
 use ark_ec::{pairing::Pairing, VariableBaseMSM};
-use ark_ff::{Field, PrimeField};
-use ark_poly::{DenseUVPolynomial, Polynomial};
-use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness, KZG10}, Error, PCCommitmentState};
+use ark_poly::{DenseUVPolynomial};
+use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness}, Error, PCCommitmentState};
 use ark_ff::Zero;
-
-use ark_std::{rand::RngCore, vec::Vec};
-
-// fn skip_leading_zeros<F: PrimeField, P: DenseUVPolynomial<F>>(
-//     p: &P,
-// ) -> usize {
-//     let mut num_leading_zeros = 0;
-//     while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
-//         num_leading_zeros += 1;
-//     }
-//     // let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
-//     num_leading_zeros
-// }
 
 pub fn fast_commit_unchecked<E, P>(
     powers: &Powers<E>,
     polynomial: &P,
-    hiding_bound: Option<usize>,
-    rng: Option<&mut dyn RngCore>,
 ) -> Result<(Commitment<E>, Randomness<E::ScalarField, P>), Error>
 where
     E: Pairing,
     P: DenseUVPolynomial<E::ScalarField>,
 {
-    // Degree check
-    // ark_poly_commit::kzg10::KZG10::<E, P>::check_degree_is_too_large(polynomial.degree(), powers.size())?;
-
     // Commit to the polynomial using raw field coeffs (no BigInt conversion)
     let coeffs = polynomial.coeffs();
     let num_leading_zeros = coeffs.iter().take_while(|c| c.is_zero()).count();
@@ -40,7 +21,7 @@ where
         plain_coeffs,
     );
 
-    let mut randomness = Randomness::<E::ScalarField, P>::empty();
+    let randomness = Randomness::<E::ScalarField, P>::empty();
 
     // If hiding is requested
     // let random_commitment = if let Some(hiding_degree) = hiding_bound {

--- a/src/pcs/univariate_pcs/msm_uncheck_kzg/my_kzg10/mod.rs
+++ b/src/pcs/univariate_pcs/msm_uncheck_kzg/my_kzg10/mod.rs
@@ -1,0 +1,63 @@
+use ark_ec::{pairing::Pairing, VariableBaseMSM};
+use ark_ff::{Field, PrimeField};
+use ark_poly::{DenseUVPolynomial, Polynomial};
+use ark_poly_commit::{kzg10::{Commitment,  Powers, Randomness, KZG10}, Error, PCCommitmentState};
+use ark_ff::Zero;
+
+use ark_std::{rand::RngCore, vec::Vec};
+
+// fn skip_leading_zeros<F: PrimeField, P: DenseUVPolynomial<F>>(
+//     p: &P,
+// ) -> usize {
+//     let mut num_leading_zeros = 0;
+//     while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
+//         num_leading_zeros += 1;
+//     }
+//     // let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);
+//     num_leading_zeros
+// }
+
+pub fn fast_commit_unchecked<E, P>(
+    powers: &Powers<E>,
+    polynomial: &P,
+    hiding_bound: Option<usize>,
+    rng: Option<&mut dyn RngCore>,
+) -> Result<(Commitment<E>, Randomness<E::ScalarField, P>), Error>
+where
+    E: Pairing,
+    P: DenseUVPolynomial<E::ScalarField>,
+{
+    // Degree check
+    // ark_poly_commit::kzg10::KZG10::<E, P>::check_degree_is_too_large(polynomial.degree(), powers.size())?;
+
+    // Commit to the polynomial using raw field coeffs (no BigInt conversion)
+    let coeffs = polynomial.coeffs();
+    let num_leading_zeros = coeffs.iter().take_while(|c| c.is_zero()).count();
+    let plain_coeffs = &coeffs[num_leading_zeros..];
+
+    let commitment = E::G1::msm_unchecked(
+        &powers.powers_of_g[num_leading_zeros..],
+        plain_coeffs,
+    );
+
+    let mut randomness = Randomness::<E::ScalarField, P>::empty();
+
+    // If hiding is requested
+    // let random_commitment = if let Some(hiding_degree) = hiding_bound {
+    //     let mut rng = rng.ok_or(Error::MissingRng)?;
+    //     randomness = Randomness::rand(hiding_degree, false, None, &mut rng);
+    //     ark_poly_commit::kzg10::KZG10::<E, P>::check_hiding_bound(
+    //         randomness.blinding_polynomial.degree(),
+    //         powers.powers_of_gamma_g.len(),
+    //     )?;
+
+    //     let blind_coeffs = randomness.blinding_polynomial.coeffs();
+    //     E::G1::msm_unchecked(&powers.powers_of_gamma_g, blind_coeffs).into_affine()
+    // } else {
+    //     E::G1::zero().into_affine()
+    // };
+
+    // let final_commitment = commitment + &random_commitment;
+    let final_commitment = commitment;
+    Ok((Commitment(final_commitment.into()), randomness))
+}


### PR DESCRIPTION
This is a refactored KZG module whose `commit` method is being implemented with `msm_unchecked` instead of `msm_bigint`.

Caveats:

The new `commit` accepts only 2 parameters, with the following signature:
```
pub fn fast_commit_unchecked<E, P>(
    powers: &Powers<E>,
    polynomial: &P,
) -> Result<(Commitment<E>, Randomness<E::ScalarField, P>), Error>
where
    E: Pairing,
    P: DenseUVPolynomial<E::ScalarField>,
```

Originally there are 2 more parameters:
```
        hiding_bound: Option<usize>,
        rng: Option<&mut dyn RngCore>,
```

But they were all set to `None` in your implementation. So, I omitted them.