### PR TITLE
Add Support for Arbitrary Polynomial Expressions via Parser and bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "merlin",
  "num-traits",
  "rayon",
+ "regex",
  "sha2",
  "sha3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 ark-ed-on-bls12-381 ={ version = "0.5.0", default-features = false}
 sha2 = "0.10"
+regex = "1.11.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/bin/run_bins.sh
+++ b/bin/run_bins.sh
@@ -18,6 +18,19 @@ MAX_SIZE=16
 # echo "Running: $CMD"
 # eval $CMD
 
+# Polynomials for testing
+POLY="q1*q2*q3"
+POLY="q1*q2*q3*q4*q5"
+POLY="q1*q2*q3*q4*q5*q6*q7*q8*q*q"
+POLY="q1*q2*q3 + q1*q2*q4"
+POLY="q1*q2*q3 + q1*q2*q4 + q1*q3*q4"
+POLY="q1*q2*q3 + q1*q2*q4 + q1*q3*q4 + q2*q3*q4"
+POLY="q1*q2 + q1*q2*q3"
+POLY="q1*q2*q3 + q1*q2*q4 + q1*q3*q4"
+POLY="q1*q2*q3 + q1*q3*q4 + q2*q3*q4 + q1*q2*q5"
+POLY="q1*q2*q3 + q1*q2*q4 + q1*q2*q5 + q1*q2*q6 + q1*q2*q7 + q1*q2*q8 + q1*q2*q9"
+
+
 
 
 ############################################################

--- a/bin/univar_opt_bench_multhr.rs
+++ b/bin/univar_opt_bench_multhr.rs
@@ -32,7 +32,7 @@ fn prepare_input_evals_domain<'a>(
     let inp_evals = prepare_zero_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
     let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
-    let max_degree = inp_evals.evals_info.max_multiplicand * degree;
+    let max_degree = (inp_evals.evals_info.max_multiplicand - 1) * degree;
     let duration = instant.elapsed().as_secs_f64();
     println!("Preparing input evaluations and domain for 2^{size} work ....{duration}s");
     return (inp_evals, domain, max_degree);

--- a/bin/univar_opt_bench_multhr.rs
+++ b/bin/univar_opt_bench_multhr.rs
@@ -28,11 +28,14 @@ fn prepare_input_evals_domain<'a>(
     println!("Preparing input evaluations and domain for 2^{size} work");
     let instant = Instant::now();
 
-    let degree = 1 << size;
-    let inp_evals = prepare_zero_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
-    let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
+    let number_of_coeffs = 1 << size;
+    let inp_evals = prepare_zero_virtual_evaluation_from_string(&intput_poly, number_of_coeffs, &pool_prepare).unwrap();
+    let domain = GeneralEvaluationDomain::<Fr>::new(number_of_coeffs).unwrap();
 
-    let max_degree = (inp_evals.evals_info.max_multiplicand - 1) * degree;
+    // The degree of the input polynomial
+    // -1 here because the max_degree is for setting up the global params, 
+    // and the set up takes in mathematical `degree`, which is `number_of_coeffs - 1`.
+    let max_degree = (inp_evals.evals_info.max_multiplicand - 1) * number_of_coeffs -1;
     let duration = instant.elapsed().as_secs_f64();
     println!("Preparing input evaluations and domain for 2^{size} work ....{duration}s");
     return (inp_evals, domain, max_degree);

--- a/bin/univar_opt_bench_multhr.rs
+++ b/bin/univar_opt_bench_multhr.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use std::iter::zip;
 use std::time::Instant;
 use zerocheck::transcripts::ZCTranscript;
-use zerocheck::zc::univariate_zc::custom::data_structures::custom_zero_test_case_with_products;
 use zerocheck::zc::univariate_zc::custom::{
     data_structures::{VirtualEvaluation, ZeroCheckParams},
     CustomUnivariateZeroCheck,
@@ -30,7 +29,8 @@ fn prepare_input_evals_domain<'a>(
     let instant = Instant::now();
 
     let degree = 1 << size;
-    let inp_evals = prepare_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
+    let inp_evals =
+        prepare_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
     let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
     let max_degree = inp_evals.evals_info.max_multiplicand * degree;
@@ -239,7 +239,8 @@ fn bench_opt_uni_zc() {
                 .build()
                 .unwrap();
 
-            let (input_evals, domain, pp) = prepare_input_evals_domain(size, &pool_prepare, args.f.clone());
+            let (input_evals, domain, pp) =
+                prepare_input_evals_domain(size, &pool_prepare, args.f.clone());
 
             let total_runtime: u128 = match args.poly_commit_scheme.as_str() {
                 "kzg" => {

--- a/bin/univar_opt_bench_multhr.rs
+++ b/bin/univar_opt_bench_multhr.rs
@@ -15,7 +15,7 @@ use zerocheck::{
         kzg::KZG,
         ligero::{Ligero, LigeroPoseidon},
     },
-    zc::univariate_zc::custom::parser::prepare_virtual_evaluation_from_string,
+    zc::univariate_zc::custom::parser::prepare_zero_virtual_evaluation_from_string,
 };
 
 /// This function prepares the random input evaluations for the prover test.
@@ -29,8 +29,7 @@ fn prepare_input_evals_domain<'a>(
     let instant = Instant::now();
 
     let degree = 1 << size;
-    let inp_evals =
-        prepare_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
+    let inp_evals = prepare_zero_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
     let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
     let max_degree = inp_evals.evals_info.max_multiplicand * degree;

--- a/bin/univar_opt_bench_multhr.rs
+++ b/bin/univar_opt_bench_multhr.rs
@@ -4,30 +4,36 @@ use ark_std::{end_timer, start_timer};
 use clap::Parser;
 use std::iter::zip;
 use std::time::Instant;
-use zerocheck::pcs::univariate_pcs::{
-    kzg::KZG,
-    ligero::{Ligero, LigeroPoseidon},
-};
 use zerocheck::transcripts::ZCTranscript;
-use zerocheck::zc::univariate_zc::custom::{CustomUnivariateZeroCheck, data_structures::{VirtualEvaluation, ZeroCheckParams}};
-use zerocheck::ZeroCheck;
 use zerocheck::zc::univariate_zc::custom::data_structures::custom_zero_test_case_with_products;
+use zerocheck::zc::univariate_zc::custom::{
+    data_structures::{VirtualEvaluation, ZeroCheckParams},
+    CustomUnivariateZeroCheck,
+};
+use zerocheck::ZeroCheck;
+use zerocheck::{
+    pcs::univariate_pcs::{
+        kzg::KZG,
+        ligero::{Ligero, LigeroPoseidon},
+    },
+    zc::univariate_zc::custom::parser::prepare_virtual_evaluation_from_string,
+};
 
 /// This function prepares the random input evaluations for the prover test.
 /// Reuse for the same worksize across multiple repeated tests.
 fn prepare_input_evals_domain<'a>(
     size: usize,
-    num_polys: usize,
-    prod_sizes: Vec<usize>,
     pool_prepare: &rayon::ThreadPool,
+    intput_poly: String,
 ) -> (VirtualEvaluation<Fr>, GeneralEvaluationDomain<Fr>, usize) {
     println!("Preparing input evaluations and domain for 2^{size} work");
     let instant = Instant::now();
-    let domain = GeneralEvaluationDomain::<Fr>::new(size).unwrap();
 
-    let inp_evals = custom_zero_test_case_with_products::<Fr>(size, num_polys, prod_sizes.clone(), pool_prepare);
+    let degree = 1 << size;
+    let inp_evals = prepare_virtual_evaluation_from_string(&intput_poly, degree, &pool_prepare).unwrap();
+    let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
-    let max_degree = size * num_polys * 2;
+    let max_degree = inp_evals.evals_info.max_multiplicand * degree;
     let duration = instant.elapsed().as_secs_f64();
     println!("Preparing input evaluations and domain for 2^{size} work ....{duration}s");
     return (inp_evals, domain, max_degree);
@@ -197,14 +203,6 @@ struct Args {
     #[arg(long, default_value = "20")]
     max_size: usize,
 
-    /// Number of polynomials to use for the test
-    #[arg(long, default_value = "5")]
-    num_polys: usize,
-
-    /// Number of products to use for the test
-    #[arg(long, value_delimiter = ',', default_value = "5,4,3,2,1")]
-    prod_sizes: Vec<usize>,
-
     /// Number of threads to use for prepare input evaluations
     #[arg(long, default_value = "64")]
     prepare_threads: usize,
@@ -224,6 +222,9 @@ struct Args {
     /// Number of threads to run batch commit
     #[arg(long, default_value = "1")]
     batch_commit_threads: usize,
+
+    #[arg(long, default_value = "g*h*s + (1 - s)*(g + h)")]
+    f: String,
 }
 
 fn bench_opt_uni_zc() {
@@ -238,8 +239,7 @@ fn bench_opt_uni_zc() {
                 .build()
                 .unwrap();
 
-            let (input_evals, domain, pp) =
-                prepare_input_evals_domain(size, args.num_polys, args.prod_sizes.clone(), &pool_prepare);
+            let (input_evals, domain, pp) = prepare_input_evals_domain(size, &pool_prepare, args.f.clone());
 
             let total_runtime: u128 = match args.poly_commit_scheme.as_str() {
                 "kzg" => {

--- a/src/zc/univariate_zc/custom/data_structures.rs
+++ b/src/zc/univariate_zc/custom/data_structures.rs
@@ -209,10 +209,9 @@ impl<F: PrimeField> VirtualPolynomial<F> {
         self.products
             .iter()
             .map(|(_, indices)| {
-                indices
-                    .iter()
-                    .map(|&index| self.univariate_polynomials[index].degree())
-                    .sum::<usize>()
+                indices.iter().map(|&index| {
+                    self.univariate_polynomials[index].degree() + 1
+                }).sum::<usize>()
             })
             .max()
             .unwrap_or(0)

--- a/src/zc/univariate_zc/custom/data_structures.rs
+++ b/src/zc/univariate_zc/custom/data_structures.rs
@@ -163,7 +163,7 @@ pub struct PolynomialInfo<F: PrimeField> {
 
 /// Struct to store the sum of products of MLEs
 #[derive(Clone, Debug)]
-pub struct VirtualPolynomail<F: PrimeField> {
+pub struct VirtualPolynomial<F: PrimeField> {
     // information about the virtual polynomial
     pub poly_info: PolynomialInfo<F>,
     // list of (indexed) MLEs which are to be multiplied
@@ -174,7 +174,7 @@ pub struct VirtualPolynomail<F: PrimeField> {
     pub univariate_polynomials: Vec<Arc<DensePolynomial<F>>>,
 }
 
-impl<F: PrimeField> VirtualPolynomail<F> {
+impl<F: PrimeField> VirtualPolynomial<F> {
     /// Creates an empty virtual polynomial with `num_variables`
     pub fn new(virtual_evaluation: VirtualEvaluation<F>, pool_run: Option<&ThreadPool>) -> Self {
         let univariate_polynomials: Vec<Arc<DensePolynomial<F>>>;
@@ -194,7 +194,7 @@ impl<F: PrimeField> VirtualPolynomail<F> {
                 .collect();
         }
 
-        VirtualPolynomail {
+        VirtualPolynomial {
             poly_info: PolynomialInfo {
                 max_multiplicand: virtual_evaluation.evals_info.max_multiplicand,
                 phantom: PhantomData,

--- a/src/zc/univariate_zc/custom/data_structures.rs
+++ b/src/zc/univariate_zc/custom/data_structures.rs
@@ -204,7 +204,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
         }
     }
 
-    /// Returns the degree of the virtual polynomial
+    /// Returns the size (number of coefficients) of the virtual polynomial
     pub fn degree(&self) -> usize {
         self.products
             .iter()

--- a/src/zc/univariate_zc/custom/data_structures.rs
+++ b/src/zc/univariate_zc/custom/data_structures.rs
@@ -1,11 +1,13 @@
 use crate::pcs::PolynomialCommitmentScheme;
-use ark_ff::PrimeField;
-use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain};
-use std::{cmp::max, collections::HashMap, marker::PhantomData, sync::Arc};
 use anyhow::{Error, Ok};
+use ark_ff::PrimeField;
 use ark_poly::Polynomial;
-use rayon::ThreadPool;
+use ark_poly::{
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain,
+};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::ThreadPool;
+use std::{cmp::max, collections::HashMap, marker::PhantomData, sync::Arc};
 
 /// This is the data structure of the proof to be sent to the verifer,
 /// to prove that there exists a quotient polynomial q(X), for which,
@@ -89,7 +91,6 @@ impl<F: PrimeField> VirtualEvaluation<F> {
         self.evals_info.max_multiplicand = max(self.evals_info.max_multiplicand, product.len());
 
         for m in product {
-
             let m_ptr: *const Evaluations<F> = Arc::as_ptr(&m);
 
             if let Some(index) = self.raw_pointers_lookup_table.get(&m_ptr) {
@@ -113,7 +114,6 @@ impl<F: PrimeField> VirtualEvaluation<F> {
         evals: Arc<Evaluations<F>>,
         coefficient: F,
     ) -> Result<(), Error> {
-
         let evals_ptr: *const Evaluations<F> = Arc::as_ptr(&evals);
 
         let evals_index = match self.raw_pointers_lookup_table.get(&evals_ptr) {
@@ -142,14 +142,15 @@ impl<F: PrimeField> VirtualEvaluation<F> {
         for (coef, indices) in self.products.iter() {
             let mut product = coef.clone();
             for &index in indices {
-                product *= <Evaluations<F> as Clone>::clone(&self.univariate_evaluations[index]).interpolate().evaluate(&point);
+                product *= <Evaluations<F> as Clone>::clone(&self.univariate_evaluations[index])
+                    .interpolate()
+                    .evaluate(&point);
             }
             result += product;
         }
         result
     }
 }
-
 
 #[derive(Clone, Debug)]
 pub struct PolynomialInfo<F: PrimeField> {
@@ -208,13 +209,14 @@ impl<F: PrimeField> VirtualPolynomail<F> {
         self.products
             .iter()
             .map(|(_, indices)| {
-                indices.iter().map(|&index| {
-                    self.univariate_polynomials[index].degree()
-                }).sum::<usize>()
+                indices
+                    .iter()
+                    .map(|&index| self.univariate_polynomials[index].degree())
+                    .sum::<usize>()
             })
             .max()
             .unwrap_or(0)
-    }   
+    }
 
     /// Evaluates the virtual polynomial at a given point
     pub fn evaluate(&self, point: F) -> F {
@@ -230,19 +232,33 @@ impl<F: PrimeField> VirtualPolynomail<F> {
     }
 
     /// Evaluates the virtual polynomial at a given domain
-    pub fn evaluate_over_domain(&self, domain: GeneralEvaluationDomain<F>, pool_run: Option<&ThreadPool>) -> Vec<F> {
+    pub fn evaluate_over_domain(
+        &self,
+        domain: GeneralEvaluationDomain<F>,
+        pool_run: Option<&ThreadPool>,
+    ) -> Vec<F> {
         let evals: Vec<Vec<F>>;
         if let Some(pool_run) = pool_run {
             evals = pool_run.install(|| {
                 self.univariate_polynomials
                     .iter()
-                    .map(|poly| (*poly.as_ref()).clone().evaluate_over_domain(domain.clone()).evals)
+                    .map(|poly| {
+                        (*poly.as_ref())
+                            .clone()
+                            .evaluate_over_domain(domain.clone())
+                            .evals
+                    })
                     .collect()
             });
         } else {
-            evals = self.univariate_polynomials
+            evals = self
+                .univariate_polynomials
                 .iter()
-                .map(|poly| <DensePolynomial<F> as Clone>::clone(&poly).evaluate_over_domain(domain).evals)
+                .map(|poly| {
+                    <DensePolynomial<F> as Clone>::clone(&poly)
+                        .evaluate_over_domain(domain)
+                        .evals
+                })
                 .collect();
         }
 
@@ -365,7 +381,10 @@ pub fn custom_zero_test_case_with_products<F: PrimeField>(
         let mut prod = vec![];
         let mut prod_evals = vec![F::one(); degree];
         for j in 0..*i {
-            prod.push(Arc::new(Evaluations::from_vec_and_domain(poly_evals[j].clone(), domain)));
+            prod.push(Arc::new(Evaluations::from_vec_and_domain(
+                poly_evals[j].clone(),
+                domain,
+            )));
             for k in 0..degree {
                 prod_evals[k] *= poly_evals[j][k];
             }
@@ -376,9 +395,7 @@ pub fn custom_zero_test_case_with_products<F: PrimeField>(
         }
     }
 
-    let zero_evals = pool_prepare.install(|| {
-        Evaluations::from_vec_and_domain(zero_evals, domain)
-    });
+    let zero_evals = pool_prepare.install(|| Evaluations::from_vec_and_domain(zero_evals, domain));
     inp_evals.add_product(vec![Arc::new(zero_evals)], F::from(-1));
 
     inp_evals

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -297,6 +297,7 @@ where
 mod tests {
     use crate::pcs::univariate_pcs::kzg::KZG;
     use crate::pcs::univariate_pcs::ligero::Ligero;
+    use crate::zc::univariate_zc::custom::parser::prepare_virtual_evaluation_from_string;
 
     use super::*;
     use ark_bls12_381::Bls12_381;
@@ -315,13 +316,14 @@ mod tests {
             .unwrap();
 
         let degree = 1 << 6;
-        let inp_evals =
-            custom_zero_test_case_with_products::<Fr>(degree, 3, vec![3, 2, 2], &pool_prepare);
+        let input = "g*h*s + (1 - s)(g + h)";
+        let inp_evals = prepare_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
         let proof_gen_timer = start_timer!(|| "Prove fn called for g, h, zero_domain");
 
-        let max_degree = 3 * degree;
+        print!("{}", inp_evals.evals_info.max_multiplicand);
+        let max_degree = inp_evals.evals_info.max_multiplicand * degree;
 
         let zp = CustomUnivariateZeroCheck::<Fr, KZG<Bls12_381>>::setup(&max_degree).unwrap();
 

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -97,10 +97,10 @@ where
 
         // compute the vanishing polynomial of the zero domain
         // let z_poly = zero_domain.vanishing_polynomial();
-        let z_deg = zero_domain.size();
+        let z_size = zero_domain.size();
 
         let prove_time = start_timer!(|| format!(
-            "OptimizedUnivariateZeroCheck::prove, with {z_deg} zero_domain size."
+            "OptimizedUnivariateZeroCheck::prove, with {z_size} zero_domain size."
         ));
 
         let ifft_time = start_timer!(|| "IFFT for g,h,s,o from evaluations to coefficients");
@@ -113,11 +113,11 @@ where
         let coset_time = start_timer!(|| "Compute coset domain");
 
         // compute degree of quotient polynomial to
-        let f_deg = virtual_polynomial.degree();
-        let q_deg = f_deg - z_deg;
+        let f_size = virtual_polynomial.degree();
+        let q_size = f_size - z_size;
 
         // Compute the coset domain to interpolate q(X)
-        let q_domain = GeneralEvaluationDomain::<F>::new(q_deg).unwrap();
+        let q_domain = GeneralEvaluationDomain::<F>::new(q_size).unwrap();
         let offset = F::GENERATOR;
         let coset_domain: GeneralEvaluationDomain<F> = q_domain.get_coset(offset).unwrap();
 

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     // This function tests the proof and verification combined with parser
-    fn test_proof_generation_verification_with_parser(){
+    fn test_proof_generation_verification_with_parser() {
         let test_timer = start_timer!(|| "Proof Generation Test");
         let pool_prepare = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
@@ -317,12 +317,12 @@ mod tests {
 
         let degree = 1 << 6;
         let input = "g*h*s + (1 - s)*(g + h)";
-        let inp_evals = prepare_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
+        let inp_evals =
+            prepare_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
         let proof_gen_timer = start_timer!(|| "Prove fn called for g, h, zero_domain");
 
-        print!("{}", inp_evals.evals_info.max_multiplicand);
         let max_degree = inp_evals.evals_info.max_multiplicand * degree;
 
         let zp = CustomUnivariateZeroCheck::<Fr, KZG<Bls12_381>>::setup(&max_degree).unwrap();

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -106,8 +106,8 @@ where
         let ifft_time = start_timer!(|| "IFFT for g,h,s,o from evaluations to coefficients");
 
         // compute the polynomials corresponding to g, h, and s using interpolation (IFFT)
-        let virtual_polynomial: VirtualPolynomail<F> =
-            VirtualPolynomail::new(input_poly.clone(), Some(&pool_run));
+        let virtual_polynomial: VirtualPolynomial<F> =
+            VirtualPolynomial::new(input_poly.clone(), Some(&pool_run));
 
         end_timer!(ifft_time);
         let coset_time = start_timer!(|| "Compute coset domain");

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -117,7 +117,7 @@ where
         let q_deg = f_deg - z_deg;
 
         // Compute the coset domain to interpolate q(X)
-        let q_domain = GeneralEvaluationDomain::<F>::new(q_deg + 1).unwrap();
+        let q_domain = GeneralEvaluationDomain::<F>::new(q_deg).unwrap();
         let offset = F::GENERATOR;
         let coset_domain: GeneralEvaluationDomain<F> = q_domain.get_coset(offset).unwrap();
 

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -14,6 +14,8 @@ use crate::pcs::PolynomialCommitmentScheme;
 use crate::transcripts::ZCTranscript;
 use crate::ZeroCheck;
 
+pub mod parser;
+
 /// Optimized Zero-Check protocol for if a polynomial
 /// f = g*h*s + (1 - s)(g + h) - o evaluates to 0
 /// over a specific domain using NTTs and INTTs
@@ -104,7 +106,8 @@ where
         let ifft_time = start_timer!(|| "IFFT for g,h,s,o from evaluations to coefficients");
 
         // compute the polynomials corresponding to g, h, and s using interpolation (IFFT)
-        let virtual_polynomial: VirtualPolynomail<F> = VirtualPolynomail::new(input_poly.clone(), Some(&pool_run));
+        let virtual_polynomial: VirtualPolynomail<F> =
+            VirtualPolynomail::new(input_poly.clone(), Some(&pool_run));
 
         end_timer!(ifft_time);
         let coset_time = start_timer!(|| "Compute coset domain");
@@ -162,13 +165,8 @@ where
             .collect();
 
         // Use the pool_commit thread pool to perform the batch_commit operation
-        let input_polynomial_comms = pool_commit.install(|| {
-            PCS::batch_commit(
-                &zero_params.ck,
-                &flatten_polynomials,
-            )
-            .unwrap()
-        });
+        let input_polynomial_comms = pool_commit
+            .install(|| PCS::batch_commit(&zero_params.ck, &flatten_polynomials).unwrap());
         end_timer!(commit_time);
         let commit_q_time = start_timer!(|| "Commit to (q) polynomial");
 
@@ -210,13 +208,7 @@ where
 
         // Generate the opening proof that g(r), h(r), s(r), and o(r) are the evaluations of the polynomials
         let mut opening_proofs = pool_open.install(|| {
-            PCS::batch_open(
-                &zero_params.ck,
-                &batch_comms,
-                &batch_polynomials,
-                r,
-            )
-            .unwrap()
+            PCS::batch_open(&zero_params.ck, &batch_comms, &batch_polynomials, r).unwrap()
         });
 
         let q_opening_proof = opening_proofs[opening_proofs.len() - 1].clone();
@@ -309,10 +301,7 @@ mod tests {
     use super::*;
     use ark_bls12_381::Bls12_381;
     use ark_bls12_381::Fr;
-    use ark_poly::{
-        EvaluationDomain,
-        GeneralEvaluationDomain,
-    };
+    use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
     use ark_std::end_timer;
     use ark_std::start_timer;
 
@@ -325,7 +314,8 @@ mod tests {
             .unwrap();
 
         let degree = 1 << 6;
-        let inp_evals = custom_zero_test_case_with_products::<Fr>(degree, 3, vec![3, 2, 2], &pool_prepare);
+        let inp_evals =
+            custom_zero_test_case_with_products::<Fr>(degree, 3, vec![3, 2, 2], &pool_prepare);
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
         let proof_gen_timer = start_timer!(|| "Prove fn called for g, h, zero_domain");
@@ -374,7 +364,8 @@ mod tests {
 
         let degree = 1 << 5;
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
-        let inp_evals = custom_zero_test_case_with_products::<Fr>(degree, 3, vec![3, 2, 2], &pool_prepare);
+        let inp_evals =
+            custom_zero_test_case_with_products::<Fr>(degree, 3, vec![3, 2, 2], &pool_prepare);
 
         let proof_gen_timer = start_timer!(|| "Prove fn called for g, h, zero_domain");
 

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -316,7 +316,7 @@ mod tests {
             .unwrap();
 
         let degree = 1 << 6;
-        let input = "g*h*s + (1 - s)(g + h)";
+        let input = "g*h*s + (1 - s)*(g + h)";
         let inp_evals = prepare_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 

--- a/src/zc/univariate_zc/custom/mod.rs
+++ b/src/zc/univariate_zc/custom/mod.rs
@@ -297,7 +297,7 @@ where
 mod tests {
     use crate::pcs::univariate_pcs::kzg::KZG;
     use crate::pcs::univariate_pcs::ligero::Ligero;
-    use crate::zc::univariate_zc::custom::parser::prepare_virtual_evaluation_from_string;
+    use crate::zc::univariate_zc::custom::parser::prepare_zero_virtual_evaluation_from_string;
 
     use super::*;
     use ark_bls12_381::Bls12_381;
@@ -318,7 +318,7 @@ mod tests {
         let degree = 1 << 6;
         let input = "g*h*s + (1 - s)*(g + h)";
         let inp_evals =
-            prepare_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
+            prepare_zero_virtual_evaluation_from_string(input, degree, &pool_prepare).unwrap();
         let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
 
         let proof_gen_timer = start_timer!(|| "Prove fn called for g, h, zero_domain");

--- a/src/zc/univariate_zc/custom/parser.rs
+++ b/src/zc/univariate_zc/custom/parser.rs
@@ -392,7 +392,7 @@ pub fn extract_variable_names(input: &str) -> Vec<String> {
 // e.g. `x + 2*y - 3*z^2 + (4 - x)`
 //
 // A zeroizing variable `o` is automatically added, for testing purposes.
-pub fn prepare_virtual_evaluation_from_string<F>(
+pub fn prepare_zero_virtual_evaluation_from_string<F>(
     input: &str,
     degree: usize,
     pool_prepare: &rayon::ThreadPool,

--- a/src/zc/univariate_zc/custom/parser.rs
+++ b/src/zc/univariate_zc/custom/parser.rs
@@ -1,0 +1,346 @@
+#![allow(dead_code)]
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use ark_ff::PrimeField;
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain};
+
+use super::data_structures::*;
+
+// use crate::your_module::ParseError as InternalParseError; // optional
+
+// --- Parser errors (local) ---
+#[derive(Debug)]
+pub enum ParseError {
+    UnexpectedChar(char, usize),
+    UnexpectedEnd,
+    UnknownVar(String),
+    InvalidNumber(String),
+    UnbalancedParens,
+    Other(String),
+}
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ParseError::*;
+        match self {
+            UnexpectedChar(c, i) => write!(f, "Unexpected char '{}' at {}", c, i),
+            UnexpectedEnd => write!(f, "Unexpected end of input"),
+            UnknownVar(s) => write!(f, "Unknown variable '{}'", s),
+            InvalidNumber(s) => write!(f, "Invalid number '{}'", s),
+            UnbalancedParens => write!(f, "Unbalanced parentheses"),
+            Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+impl std::error::Error for ParseError {}
+
+// --- AST ---
+#[derive(Debug, Clone)]
+enum Node {
+    Var(String),
+    Const(i64),
+    Add(Box<Node>, Box<Node>),
+    Sub(Box<Node>, Box<Node>),
+    Mul(Box<Node>, Box<Node>),
+    Pow(Box<Node>, u32),
+}
+
+// --- Parser (very similar to previous prototype) ---
+struct Parser<'a> {
+    chars: Vec<char>,
+    pos: usize,
+    _inp: &'a str,
+}
+impl<'a> Parser<'a> {
+    fn new(s: &'a str) -> Self {
+        Self { chars: s.chars().collect(), pos: 0, _inp: s }
+    }
+    fn peek(&self) -> Option<char> { self.chars.get(self.pos).copied() }
+    fn bump(&mut self) -> Option<char> { let c = self.peek(); if c.is_some() { self.pos += 1; } c }
+    fn eat_ws(&mut self) { while matches!(self.peek(), Some(c) if c.is_whitespace()) { self.pos += 1; } }
+
+    fn parse(&mut self) -> Result<Node, ParseError> {
+        self.eat_ws();
+        let n = self.parse_expr()?;
+        self.eat_ws();
+        if self.pos < self.chars.len() {
+            return Err(ParseError::UnexpectedChar(self.chars[self.pos], self.pos));
+        }
+        Ok(n)
+    }
+
+    fn parse_expr(&mut self) -> Result<Node, ParseError> {
+        let mut node = self.parse_term()?;
+        loop {
+            self.eat_ws();
+            match self.peek() {
+                Some('+') => { self.bump(); let rhs = self.parse_term()?; node = Node::Add(Box::new(node), Box::new(rhs)); }
+                Some('-') => { self.bump(); let rhs = self.parse_term()?; node = Node::Sub(Box::new(node), Box::new(rhs)); }
+                _ => break,
+            }
+        }
+        Ok(node)
+    }
+
+    fn parse_term(&mut self) -> Result<Node, ParseError> {
+        let mut node = self.parse_factor()?;
+        loop {
+            self.eat_ws();
+            // '*' for multiply, but treat '**' (power) specially in factor
+            if let Some('*') = self.peek() {
+                if self.pos + 1 < self.chars.len() && self.chars[self.pos + 1] == '*' {
+                    // power operator handled in factor -> break
+                    break;
+                } else {
+                    self.bump();
+                    let rhs = self.parse_factor()?;
+                    node = Node::Mul(Box::new(node), Box::new(rhs));
+                }
+            } else {
+                break;
+            }
+        }
+        Ok(node)
+    }
+
+    fn parse_factor(&mut self) -> Result<Node, ParseError> {
+        self.eat_ws();
+        match self.peek() {
+            Some('(') => {
+                self.bump();
+                let inner = self.parse_expr()?;
+                self.eat_ws();
+                if self.peek() == Some(')') { self.bump(); self.parse_pow_suffix(inner) }
+                else { Err(ParseError::UnbalancedParens) }
+            }
+            Some(c) if is_ident_start(c) => {
+                let id = self.parse_ident();
+                self.parse_pow_suffix(Node::Var(id))
+            }
+            Some(c) if c.is_ascii_digit() => {
+                let n = self.parse_number()?;
+                self.parse_pow_suffix(Node::Const(n))
+            }
+            Some('-') => {
+                self.bump();
+                // unary minus -> 0 - factor
+                let f = self.parse_factor()?;
+                Ok(Node::Sub(Box::new(Node::Const(0)), Box::new(f)))
+            }
+            Some(c) => Err(ParseError::UnexpectedChar(c, self.pos)),
+            None => Err(ParseError::UnexpectedEnd),
+        }
+    }
+
+    fn parse_pow_suffix(&mut self, base: Node) -> Result<Node, ParseError> {
+        self.eat_ws();
+        if let Some('^') = self.peek() {
+            self.bump();
+            let e = self.parse_unsigned_integer()?;
+            Ok(Node::Pow(Box::new(base), e as u32))
+        } else if let Some('*') = self.peek() {
+            if self.pos + 1 < self.chars.len() && self.chars[self.pos + 1] == '*' {
+                self.pos += 2;
+                let e = self.parse_unsigned_integer()?;
+                Ok(Node::Pow(Box::new(base), e as u32))
+            } else { Ok(base) }
+        } else {
+            Ok(base)
+        }
+    }
+
+    fn parse_ident(&mut self) -> String {
+        let mut s = String::new();
+        if let Some(c) = self.peek() { if is_ident_start(c) { s.push(c); self.bump(); } }
+        while let Some(c) = self.peek() { if is_ident_continue(c) { s.push(c); self.bump(); } else { break; } }
+        s
+    }
+
+    fn parse_number(&mut self) -> Result<i64, ParseError> {
+        let mut s = String::new();
+        while let Some(c) = self.peek() { if c.is_ascii_digit() { s.push(c); self.bump(); } else { break; } }
+        s.parse::<i64>().map_err(|_| ParseError::InvalidNumber(s))
+    }
+
+    fn parse_unsigned_integer(&mut self) -> Result<u64, ParseError> {
+        let mut s = String::new();
+        while let Some(c) = self.peek() { if c.is_ascii_digit() { s.push(c); self.bump(); } else { break; } }
+        if s.is_empty() { return Err(ParseError::Other("expected integer".into())); }
+        s.parse::<u64>().map_err(|_| ParseError::Other(format!("invalid {}", s)))
+    }
+}
+
+fn is_ident_start(c: char) -> bool { c.is_ascii_alphabetic() || c == '_' }
+fn is_ident_continue(c: char) -> bool { c.is_ascii_alphanumeric() || c == '_' }
+
+// --- Convert AST to intermediate product-list ---
+// ProductArc = (coefficient: F, refs: Vec<Arc<Evaluations<F>>>)
+type ProductArc<F> = (F, Vec<Arc<Evaluations<F>>>);
+
+fn ast_to_products<F>(
+    node: &Node,
+    var_map: &HashMap<String, Arc<Evaluations<F>>>,
+    const_to_eval: &dyn Fn(i64) -> Arc<Evaluations<F>>,
+    int_to_field: &dyn Fn(i64) -> F,
+) -> Result<Vec<ProductArc<F>>, ParseError>
+where
+    F: PrimeField + Clone,
+{
+    match node {
+        Node::Var(name) => {
+            let arc = var_map.get(name).ok_or_else(|| ParseError::UnknownVar(name.clone()))?;
+            Ok(vec![(int_to_field(1), vec![Arc::clone(arc)])])
+        }
+        Node::Const(n) => {
+            // represent numeric constant as a constant evaluation vector (Arc<Evaluations<F>>)
+            let const_arc = const_to_eval(*n);
+            Ok(vec![(int_to_field(1), vec![const_arc])])
+        }
+        Node::Add(l, r) => {
+            let mut left = ast_to_products::<F>(l, var_map, const_to_eval, int_to_field)?;
+            let right = ast_to_products::<F>(r, var_map, const_to_eval, int_to_field)?;
+            left.extend(right.into_iter());
+            Ok(left)
+        }
+        Node::Sub(l, r) => {
+            let mut left = ast_to_products::<F>(l, var_map, const_to_eval, int_to_field)?;
+            let mut right = ast_to_products::<F>(r, var_map, const_to_eval, int_to_field)?;
+            // negate right coefficients
+            let minus_one = int_to_field(-1);
+            for (coef, _refs) in right.iter_mut() {
+                *coef = coef.clone() * minus_one.clone();
+            }
+            left.extend(right.into_iter());
+            Ok(left)
+        }
+        Node::Mul(l, r) => {
+            let left = ast_to_products::<F>(l, var_map, const_to_eval, int_to_field)?;
+            let right = ast_to_products::<F>(r, var_map, const_to_eval, int_to_field)?;
+            let mut out = Vec::with_capacity(left.len() * right.len());
+            for (ca, ra) in left.iter() {
+                for (cb, rb) in right.iter() {
+                    let mut refs = Vec::with_capacity(ra.len() + rb.len());
+                    refs.extend(ra.iter().cloned());
+                    refs.extend(rb.iter().cloned());
+                    let coef = ca.clone() * cb.clone();
+                    out.push((coef, refs));
+                }
+            }
+            Ok(out)
+        }
+        Node::Pow(base, exp) => {
+            let mut acc: Option<Vec<ProductArc<F>>> = None;
+            let mut base_prods = ast_to_products::<F>(base, var_map, const_to_eval, int_to_field)?;
+            let mut e = *exp;
+            while e > 0 {
+                if (e & 1) == 1 {
+                    acc = Some(match acc {
+                        None => base_prods.clone(),
+                        Some(a) => mul_product_lists::<F>(&a, &base_prods),
+                    });
+                }
+                e >>= 1;
+                if e > 0 {
+                    base_prods = mul_product_lists::<F>(&base_prods, &base_prods);
+                }
+            }
+            Ok(acc.unwrap_or_else(|| vec![]))
+        }
+    }
+}
+
+/// Multiply two product-lists: cross product and combine refs/coefs
+fn mul_product_lists<F>(a: &Vec<ProductArc<F>>, b: &Vec<ProductArc<F>>) -> Vec<ProductArc<F>>
+where
+    F: PrimeField + Clone,
+{
+    let mut res = Vec::with_capacity(a.len() * b.len());
+    for (ca, ra) in a.iter() {
+        for (cb, rb) in b.iter() {
+            let mut refs = Vec::with_capacity(ra.len() + rb.len());
+            refs.extend(ra.iter().cloned());
+            refs.extend(rb.iter().cloned());
+            let coef = ca.clone() * cb.clone();
+            res.push((coef, refs));
+        }
+    }
+    res
+}
+
+// --- Public entry point ---
+/// Parse `input` into `VirtualEvaluation<F>`.
+///
+/// - `var_map` maps variable names to precomputed `Arc<Evaluations<F>>`.
+/// - `const_to_eval` should produce an `Arc<Evaluations<F>>` that is the constant vector equal to the input integer on the domain.
+/// - `int_to_field` converts small integers into `F` (used for negation and internal coefficients).
+pub fn parse_to_virtual_evaluation<F>(
+    input: &str,
+    var_map: &HashMap<String, Arc<Evaluations<F>>>,
+    const_to_eval: &dyn Fn(i64) -> Arc<Evaluations<F>>,
+    int_to_field: &dyn Fn(i64) -> F,
+) -> Result<VirtualEvaluation<F>, ParseError>
+where
+    F: PrimeField + Clone,
+{
+    let mut parser = Parser::new(input);
+    let ast = parser.parse()?;
+    let products = ast_to_products::<F>(&ast, var_map, const_to_eval, int_to_field)?;
+
+    // assemble into real VirtualEvaluation<F>
+    let mut ve = VirtualEvaluation::new();
+
+    for (coef, refs) in products.into_iter() {
+        // refs: Vec<Arc<Evaluations<F>>>; add_product will deduplicate pointers internally
+        ve.add_product(refs.into_iter(), coef);
+    }
+
+    Ok(ve)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381::Fr;
+    use ark_poly::domain::GeneralEvaluationDomain;
+    use ark_poly::Evaluations;
+    use std::sync::Arc;
+
+    // NOTE: test uses small domain and simple const->eval factory
+    #[test]
+    fn parse_into_virtual_eval_smoke() {
+        let degree = 4usize;
+        let domain = GeneralEvaluationDomain::<Fr>::new(degree).unwrap();
+
+        // prepare var_map: g,h,s -> random evals (here deterministic small vectors)
+        let g_vals: Vec<Fr> = (0..degree).map(|i| Fr::from(i as u64 + 1u64)).collect();
+        let h_vals: Vec<Fr> = (0..degree).map(|i| Fr::from(i as u64 + 2u64)).collect();
+        let s_vals: Vec<Fr> = (0..degree).map(|i| Fr::from(i as u64 + 3u64)).collect();
+
+        let g_arc = Arc::new(Evaluations::from_vec_and_domain(g_vals, domain));
+        let h_arc = Arc::new(Evaluations::from_vec_and_domain(h_vals, g_arc.domain().clone()));
+        let s_arc = Arc::new(Evaluations::from_vec_and_domain(s_vals, g_arc.domain().clone()));
+
+        let mut var_map: HashMap<String, Arc<Evaluations<Fr>>> = HashMap::new();
+        var_map.insert("g".to_string(), g_arc.clone());
+        var_map.insert("h".to_string(), h_arc.clone());
+        var_map.insert("s".to_string(), s_arc.clone());
+
+        // const -> eval factory (create constant vector on same domain)
+        let const_factory = |n: i64| {
+            let vals: Vec<Fr> = (0..degree).map(|_| Fr::from(n as u64)).collect();
+            Arc::new(Evaluations::from_vec_and_domain(vals, g_arc.domain().clone()))
+        };
+        let int_to_field = |n: i64| Fr::from((n as i128) as i64 as u64);
+
+        // parse
+        let expr = "g*h*s + (1 - s)*(g + h) - 5";
+        let ve = parse_to_virtual_evaluation::<Fr>(expr, &var_map, &const_factory, &int_to_field)
+            .expect("parse ok");
+
+        // Basic sanity: products should be non-empty
+        assert!(ve.products.len() > 0);
+        // max_multiplicand should be set >= 1
+        assert!(ve.evals_info.max_multiplicand >= 1);
+    }
+}

--- a/src/zc/univariate_zc/mod.rs
+++ b/src/zc/univariate_zc/mod.rs
@@ -1,3 +1,3 @@
+pub mod custom;
 pub mod naive;
 pub mod optimized;
-pub mod custom;


### PR DESCRIPTION
## Add Support for Arbitrary Polynomial Expressions via Parser

This PR introduces a parser that enables flexible input of arbitrary polynomial expressions for the univariate proof system. It also includes bug fixes, naming improvements, and benchmark updates.

### Features & Enhancements
- **Custom Input Parsing**
  - Users can now pass polynomial expressions such as `g*h*s + a*(b-c)` instead of relying on hardcoded inputs.
  - A new parser converts input strings into a structured `VirtualEvaluation`.
  - Two preparation functions are available in `parser.rs`:
    - `prepare_zero_virtual_evaluation_from_string`: wraps the input with an additional polynomial `o` that zeroizes it.
    - `prepare_virtual_evaluation_from_string`: parses the input expression as provided.
  - The `Args` struct now includes a new field `f` for user-defined expressions.
  - Internal logic has been updated to support dynamic expression trees.

### Fixes & Improvements
- **`src/zc/univariate_zc/custom/mod.rs`**
  - Fixed a critical bug caused by confusion between `degree` and `size`.
  - Clarified variable names and annotations to reduce ambiguity.
- **`src/zc/univariate_zc/custom/data_structures.rs`**
  - Corrected a typo: `VirtualPolynomail` → `VirtualPolynomial`.
- **`bin/univar_opt_bench_multhr.rs`**
  - Updated benchmarks to use the new parser-based input.
  - Removed the `num-poly` and `prod-sizes` fields from `Args`, since these are now inferred directly from expressions.
- **`bin/run_bins.sh`**
  - Added sample polynomials for testing.

### Example Command
```bash
cargo run --release --bin univar_opt_bench_multhr \
  --repeat=1 --min-size=8 --max-size=8 \
  --prepare-threads=64 --run-threads=1 \
  --poly-commit-scheme=kzg --batch-opening-threads=5 \
  --f=g*h
